### PR TITLE
Upgrade Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/AbcSize:
   Max: 16
 
 Metrics/BlockLength:
-  ExcludedMethods:
+  IgnoredMethods:
     - let
     - it
     - describe

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   # Build on the latest stable of all supported Rubies (https://www.ruby-lang.org/en/downloads/):
   - 2.5.8
   - 2.6.6
-  - 2.7.1
+  - 2.7.2
 cache: bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/dbee.gemspec
+++ b/dbee.gemspec
@@ -36,7 +36,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry', '~>0')
   s.add_development_dependency('rake', '~> 13')
   s.add_development_dependency('rspec')
-  s.add_development_dependency('rubocop', '~>0.89.1')
+  s.add_development_dependency('rubocop', '~> 1')
+  s.add_development_dependency('rubocop-rake')
+  s.add_development_dependency('rubocop-rspec')
   s.add_development_dependency('simplecov', '~>0.19.0')
   s.add_development_dependency('simplecov-console', '~>0.7.0')
 end

--- a/lib/dbee/query/field.rb
+++ b/lib/dbee/query/field.rb
@@ -26,12 +26,7 @@ module Dbee
 
       attr_reader :aggregator, :display, :filters, :key_path
 
-      def initialize(
-        aggregator: nil,
-        display: nil,
-        filters: [],
-        key_path:
-      )
+      def initialize(key_path:, aggregator: nil, display: nil, filters: [])
         raise ArgumentError, 'key_path is required' if key_path.to_s.empty?
 
         @aggregator = aggregator ? Aggregator.const_get(aggregator.to_s.upcase.to_sym) : nil

--- a/spec/dbee/constant_resolver_spec.rb
+++ b/spec/dbee/constant_resolver_spec.rb
@@ -9,23 +9,28 @@
 
 require 'spec_helper'
 
-describe Dbee::ConstantResolver do
-  module A
-    class B; end
-    class E; end
-  end
-
+# rubocop:disable Lint/EmptyClass
+# These are intentionally empty to keep the tests focused.
+module A
   class B; end
 
-  module C
-    class D; end
-    class E; end
+  class E; end
+end
 
-    module F
-      class G; end
-    end
+class B; end
+
+module C
+  class D; end
+
+  class E; end
+
+  module F
+    class G; end
   end
+end
+# rubocop:enable Lint/EmptyClass
 
+describe Dbee::ConstantResolver do
   it 'resolves nested constant with the same as an ancestor constants sibling' do
     expect(subject.constantize('A::B')).to eq(::A::B)
   end

--- a/spec/dbee/model/constraints_spec.rb
+++ b/spec/dbee/model/constraints_spec.rb
@@ -9,14 +9,13 @@
 
 require 'spec_helper'
 
+CONSTRAINT_CONFIG = { name: :a }.freeze
+CONSTRAINT_FACTORIES = {
+  Dbee::Model::Constraints::Reference => CONSTRAINT_CONFIG.merge(parent: :b, type: :reference),
+  Dbee::Model::Constraints::Static => CONSTRAINT_CONFIG.merge(value: :b, type: :static)
+}.freeze
+
 describe Dbee::Model::Constraints do
-  CONSTRAINT_CONFIG = { name: :a }.freeze
-
-  CONSTRAINT_FACTORIES = {
-    Dbee::Model::Constraints::Reference => CONSTRAINT_CONFIG.merge(parent: :b, type: :reference),
-    Dbee::Model::Constraints::Static => CONSTRAINT_CONFIG.merge(value: :b, type: :static)
-  }.freeze
-
   CONSTRAINT_FACTORIES.each_pair do |constant, config|
     it "should instantiate #{constant} objects" do
       expect(described_class.make(config)).to be_a(constant)

--- a/spec/dbee/query/filters_spec.rb
+++ b/spec/dbee/query/filters_spec.rb
@@ -9,24 +9,23 @@
 
 require 'spec_helper'
 
+FILTERS_CONFIG = { key_path: 'a.b.c', value: :d }.freeze
+FILTER_FACTORIES = {
+  Dbee::Query::Filters::Contains => FILTERS_CONFIG.merge(type: :contains),
+  Dbee::Query::Filters::Equals => FILTERS_CONFIG.merge(type: :equals),
+  Dbee::Query::Filters::GreaterThanOrEqualTo => FILTERS_CONFIG.merge(
+    type: :greater_than_or_equal_to
+  ),
+  Dbee::Query::Filters::GreaterThan => FILTERS_CONFIG.merge(type: :greater_than),
+  Dbee::Query::Filters::LessThanOrEqualTo => FILTERS_CONFIG.merge(type: :less_than_or_equal_to),
+  Dbee::Query::Filters::LessThan => FILTERS_CONFIG.merge(type: :less_than),
+  Dbee::Query::Filters::NotContain => FILTERS_CONFIG.merge(type: :not_contain),
+  Dbee::Query::Filters::NotEquals => FILTERS_CONFIG.merge(type: :not_equals),
+  Dbee::Query::Filters::NotStartWith => FILTERS_CONFIG.merge(type: :not_start_with),
+  Dbee::Query::Filters::StartsWith => FILTERS_CONFIG.merge(type: :starts_with)
+}.freeze
+
 describe Dbee::Query::Filters do
-  FILTERS_CONFIG = { key_path: 'a.b.c', value: :d }.freeze
-
-  FILTER_FACTORIES = {
-    Dbee::Query::Filters::Contains => FILTERS_CONFIG.merge(type: :contains),
-    Dbee::Query::Filters::Equals => FILTERS_CONFIG.merge(type: :equals),
-    Dbee::Query::Filters::GreaterThanOrEqualTo => FILTERS_CONFIG.merge(
-      type: :greater_than_or_equal_to
-    ),
-    Dbee::Query::Filters::GreaterThan => FILTERS_CONFIG.merge(type: :greater_than),
-    Dbee::Query::Filters::LessThanOrEqualTo => FILTERS_CONFIG.merge(type: :less_than_or_equal_to),
-    Dbee::Query::Filters::LessThan => FILTERS_CONFIG.merge(type: :less_than),
-    Dbee::Query::Filters::NotContain => FILTERS_CONFIG.merge(type: :not_contain),
-    Dbee::Query::Filters::NotEquals => FILTERS_CONFIG.merge(type: :not_equals),
-    Dbee::Query::Filters::NotStartWith => FILTERS_CONFIG.merge(type: :not_start_with),
-    Dbee::Query::Filters::StartsWith => FILTERS_CONFIG.merge(type: :starts_with)
-  }.freeze
-
   FILTER_FACTORIES.each_pair do |constant, config|
     it "should instantiate #{constant} objects" do
       expect(described_class.make(config)).to be_a(constant)

--- a/spec/dbee/query_spec.rb
+++ b/spec/dbee/query_spec.rb
@@ -9,6 +9,59 @@
 
 require 'spec_helper'
 
+README_EXAMPLES = {
+  'Get all practices' => {
+    fields: [
+      { key_path: 'id' },
+      { key_path: 'active' },
+      { key_path: 'name' }
+    ]
+  },
+  'Get all practices, limit to 10, and sort by name (descending) then id (ascending)' => {
+    fields: [
+      { key_path: 'id' },
+      { key_path: 'active' },
+      { key_path: 'name' }
+    ],
+    sorters: [
+      { key_path: 'name', direction: :descending },
+      { key_path: 'id' }
+    ],
+    limit: 10
+  },
+  "Get top 5 active practices and patient whose name start with 'Sm':" => {
+    fields: [
+      { key_path: 'name', display: 'Practice Name' },
+      { key_path: 'patients.first', display: 'Patient First Name' },
+      { key_path: 'patients.middle', display: 'Patient Middle Name' },
+      { key_path: 'patients.last', display: 'Patient Last Name' }
+    ],
+    filters: [
+      { type: :equals, key_path: 'active', value: true },
+      { type: :starts_with, key_path: 'patients.last', value: 'Sm' }
+    ],
+    limit: 5
+  },
+  'Get practice IDs, patient IDs, names, and cell phone numbers that starts with 555' => {
+    fields: [
+      { key_path: 'id', display: 'Practice ID #' },
+      { key_path: 'patients.id', display: 'Patient ID #' },
+      { key_path: 'patients.first', display: 'Patient First Name' },
+      { key_path: 'patients.middle', display: 'Patient Middle Name' },
+      { key_path: 'patients.last', display: 'Patient Last Name' },
+      { key_path: 'patients.cell_phone_numbers.phone_number', display: 'Patient Cell #' }
+    ],
+    filters: [
+      { type: :equals, key_path: 'active', value: true },
+      {
+        type: :starts_with,
+        key_path: 'patients.cell_phone_numbers.phone_number',
+        value: '555'
+      }
+    ]
+  }
+}.freeze
+
 describe Dbee::Query do
   let(:config) do
     {
@@ -116,60 +169,7 @@ describe Dbee::Query do
   end
 
   context 'README examples' do
-    EXAMPLES = {
-      'Get all practices' => {
-        fields: [
-          { key_path: 'id' },
-          { key_path: 'active' },
-          { key_path: 'name' }
-        ]
-      },
-      'Get all practices, limit to 10, and sort by name (descending) then id (ascending)' => {
-        fields: [
-          { key_path: 'id' },
-          { key_path: 'active' },
-          { key_path: 'name' }
-        ],
-        sorters: [
-          { key_path: 'name', direction: :descending },
-          { key_path: 'id' }
-        ],
-        limit: 10
-      },
-      "Get top 5 active practices and patient whose name start with 'Sm':" => {
-        fields: [
-          { key_path: 'name', display: 'Practice Name' },
-          { key_path: 'patients.first', display: 'Patient First Name' },
-          { key_path: 'patients.middle', display: 'Patient Middle Name' },
-          { key_path: 'patients.last', display: 'Patient Last Name' }
-        ],
-        filters: [
-          { type: :equals, key_path: 'active', value: true },
-          { type: :starts_with, key_path: 'patients.last', value: 'Sm' }
-        ],
-        limit: 5
-      },
-      'Get practice IDs, patient IDs, names, and cell phone numbers that starts with 555' => {
-        fields: [
-          { key_path: 'id', display: 'Practice ID #' },
-          { key_path: 'patients.id', display: 'Patient ID #' },
-          { key_path: 'patients.first', display: 'Patient First Name' },
-          { key_path: 'patients.middle', display: 'Patient Middle Name' },
-          { key_path: 'patients.last', display: 'Patient Last Name' },
-          { key_path: 'patients.cell_phone_numbers.phone_number', display: 'Patient Cell #' }
-        ],
-        filters: [
-          { type: :equals, key_path: 'active', value: true },
-          {
-            type: :starts_with,
-            key_path: 'patients.cell_phone_numbers.phone_number',
-            value: '555'
-          }
-        ]
-      }
-    }.freeze
-
-    EXAMPLES.each_pair do |name, query|
+    README_EXAMPLES.each_pair do |name, query|
       specify name do
         expect(described_class.make(query)).to be_a(described_class)
       end


### PR DESCRIPTION
Note that a big change here is that Rubocop is now enforcing that constants are not defined in blocks (Lint/ConstantDefinitionInBlock) as constants are globally scoped. See https://rubystyle.guide/#no-constant-definition-in-block for more info.