### PR TITLE
Graph based models schema spec consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ You can choose to alternatively describe your data model using configuration.  T
 practice:
   table: practices
   relationships:
-    - name: patients
+    patients:
       model: patient
       constraints:
         - type: reference
@@ -201,13 +201,13 @@ practice:
 patient:
   table: patients
   relationships:
-    - name: notes
+    notes:
       model: note
       constraints:
         - type: reference
           name: patient_id
           parent: id
-    - name: work_phone_number
+    work_phone_number:
       model: phone_number
       constraints:
         - type: reference
@@ -216,7 +216,7 @@ patient:
         - type: static
           name: phone_number_type
           value: work
-    - name: cell_phone_number
+    cell_phone_number:
       model: phone_number
       constraints:
         - type: reference
@@ -225,7 +225,7 @@ patient:
         - type: static
           name: phone_number_type
           value: cell
-    - name: fax_phone_number
+    fax_phone_number:
       model: phone_number
       constraints:
         - type: reference
@@ -449,7 +449,7 @@ Fields can be configured to use aggregation by setting its `aggregator` attribut
 practice:
   table: practices
   relationships:
-    - name: patients
+    patients:
       model: patient
       constraints:
         - type: reference

--- a/lib/dbee/dsl_schema_builder.rb
+++ b/lib/dbee/dsl_schema_builder.rb
@@ -42,7 +42,7 @@ module Dbee
         name: dsl_model.inflected_class_name,
         partitioners: dsl_model.inherited_partitioners,
         table: dsl_model.inherited_table_name,
-        relationships: []
+        relationships: {}
       }
     end
 
@@ -52,11 +52,10 @@ module Dbee
 
       schema_spec[target_model.inflected_class_name] ||= model_config(target_model)
 
-      schema_spec[base_model.inflected_class_name][:relationships].push(
-        name: association.name,
+      schema_spec[base_model.inflected_class_name][:relationships][association.name] = {
         constraints: association.constraints,
         model: relationship_model_name(association, target_model)
-      )
+      }
 
       target_model
     end

--- a/lib/dbee/model.rb
+++ b/lib/dbee/model.rb
@@ -27,6 +27,34 @@ module Dbee
     def_delegator :constraints,     :sort,    :sorted_constraints
     def_delegator :partitioners,    :sort,    :sorted_partitioners
 
+    class << self
+      # Given a hash of hashes or a hash of values of instances of this class,
+      # a hash is returned where all of the values are instances of this class.
+      # An ArgumentError is raised if the value's <tt>key_attrib</tt> is not
+      # equal to the top level hash key.
+      def make_keyed_by(key_attrib, spec_hash)
+        # Once Ruby 2.5 support is dropped, this can just use the block form of
+        # #to_h.
+        spec_hash.map do |key, spec|
+          [key, make_value_checking_key_attib!(key_attrib, key, spec)]
+        end.to_h
+      end
+
+      private
+
+      def make_value_checking_key_attib!(key_attrib, key, spec)
+        if spec.is_a?(self)
+          if spec.send(key_attrib).to_s != key.to_s
+            err_msg = "expected a #{key_attrib} of '#{key}' but got '#{spec.send(key_attrib)}'"
+            raise ArgumentError, err_msg
+          end
+          spec
+        else
+          make((spec || {}).merge(key_attrib => key))
+        end
+      end
+    end
+
     def initialize(
       name:,
       constraints: [], # Exists here for tree based model backward compatibility.
@@ -35,7 +63,7 @@ module Dbee
       partitioners: [],
       table: ''
     )
-      @name           = name.to_s
+      @name           = name
       @constraints    = Constraints.array(constraints || []).uniq
       # TODO: raise an error if two relationships share a name
       @relationships  = Relationships.array(relationships || []).to_set

--- a/lib/dbee/model/relationships.rb
+++ b/lib/dbee/model/relationships.rb
@@ -8,12 +8,14 @@
 #
 
 require_relative 'relationships/basic'
+require_relative '../util/make_keyed_by'
 
 module Dbee
   class Model
     # Top-level class that allows for the making of relationships.
     class Relationships
       acts_as_hashable_factory
+      extend Dbee::Util::MakeKeyedBy
 
       register 'basic', Basic
       register '',      Basic # When type is not present this will be the default

--- a/lib/dbee/schema.rb
+++ b/lib/dbee/schema.rb
@@ -14,7 +14,7 @@ module Dbee
 
     extend Forwardable
     def initialize(schema_config)
-      init_models_by_name(schema_config)
+      @models_by_name = Model.make_keyed_by(:name, schema_config)
 
       freeze
     end
@@ -61,24 +61,6 @@ module Dbee
     def relationship_for_name!(model, rel_name)
       model.relationship_for_name(rel_name) ||
         raise("model '#{model.name}' does not have a '#{rel_name}' relationship")
-    end
-
-    def init_models_by_name(schema_config)
-      @models_by_name = {}
-
-      schema_config.each do |model_name, model_config|
-        @models_by_name[model_name.to_s] = ensure_model_with_name(model_name, model_config)
-      end
-    end
-
-    def ensure_model_with_name(model_name, model_config)
-      if model_config.respond_to?(:name)
-        raise ArgumentError, "Expected model name #{model_name}, got #{model_config.name}" \
-          if model_name != model_config.name
-
-        return model_config
-      end
-      Model.make((model_config || {}).merge('name' => model_name))
     end
   end
 end

--- a/lib/dbee/schema_from_tree_based_model.rb
+++ b/lib/dbee/schema_from_tree_based_model.rb
@@ -25,7 +25,7 @@ module Dbee
           name: tree_model.name,
           table: tree_model.table,
           partitioners: tree_model.partitioners,
-          relationships: []
+          relationships: {}
         }
 
         parent_model && add_relationship_to_parent_model(
@@ -40,7 +40,7 @@ module Dbee
       end
 
       def add_relationship_to_parent_model(model, graph_model_attrs)
-        graph_model_attrs[:relationships].push(name: model.name, constraints: model.constraints)
+        graph_model_attrs[:relationships][model.name] = { constraints: model.constraints }
       end
     end
   end

--- a/lib/dbee/util/make_keyed_by.rb
+++ b/lib/dbee/util/make_keyed_by.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2019-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Dbee
+  module Util
+    # Provides a "make_keyed_by" method which extends the Hashable gem's
+    # concept of a "make" method.
+    module MakeKeyedBy # :nodoc:
+      # Given a hash of hashes or a hash of values of instances of this class,
+      # a hash is returned where all of the values are instances of this class.
+      # An ArgumentError is raised if the value's <tt>key_attrib</tt> is not
+      # equal to the top level hash key.
+      #
+      # This is useful for cases where it makes sense in the configuration
+      # (YAML) specification to represent certain objects in a hash structure
+      # instead of a list.
+      def make_keyed_by(key_attrib, spec_hash)
+        # Once Ruby 2.5 support is dropped, this can just use the block form of
+        # #to_h.
+        spec_hash.map do |key, spec|
+          [key, make_value_checking_key_attib!(key_attrib, key, spec)]
+        end.to_h
+      end
+
+      private
+
+      def make_value_checking_key_attib!(key_attrib, key, spec)
+        if spec.is_a?(self)
+          if spec.send(key_attrib).to_s != key.to_s
+            err_msg = "expected a #{key_attrib} of '#{key}' but got '#{spec.send(key_attrib)}'"
+            raise ArgumentError, err_msg
+          end
+          spec
+        else
+          make((spec || {}).merge(key_attrib => key))
+        end
+      end
+    end
+  end
+end

--- a/lib/dbee/util/make_keyed_by.rb
+++ b/lib/dbee/util/make_keyed_by.rb
@@ -13,9 +13,12 @@ module Dbee
     # concept of a "make" method.
     module MakeKeyedBy # :nodoc:
       # Given a hash of hashes or a hash of values of instances of this class,
-      # a hash is returned where all of the values are instances of this class.
+      # a hash is returned where all of the values are instances of this class
+      # and the keys are the string versions of the original hash.
+      #
       # An ArgumentError is raised if the value's <tt>key_attrib</tt> is not
-      # equal to the top level hash key.
+      # equal to the top level hash key. This ensures that the
+      # <tt>key_attrib</tt> is the same in the incoming hash and the value.
       #
       # This is useful for cases where it makes sense in the configuration
       # (YAML) specification to represent certain objects in a hash structure
@@ -24,7 +27,8 @@ module Dbee
         # Once Ruby 2.5 support is dropped, this can just use the block form of
         # #to_h.
         spec_hash.map do |key, spec|
-          [key, make_value_checking_key_attib!(key_attrib, key, spec)]
+          string_key = key.to_s
+          [string_key, make_value_checking_key_attib!(key_attrib, string_key, spec)]
         end.to_h
       end
 
@@ -32,7 +36,7 @@ module Dbee
 
       def make_value_checking_key_attib!(key_attrib, key, spec)
         if spec.is_a?(self)
-          if spec.send(key_attrib).to_s != key.to_s
+          if spec.send(key_attrib).to_s != key
             err_msg = "expected a #{key_attrib} of '#{key}' but got '#{spec.send(key_attrib)}'"
             raise ArgumentError, err_msg
           end

--- a/spec/dbee/model_spec.rb
+++ b/spec/dbee/model_spec.rb
@@ -55,6 +55,40 @@ describe Dbee::Model do
     end
   end
 
+  describe '.make_keyed_by' do
+    it 'returns a hash of Models where the keys equal the names of the models' do
+      input = {
+        model1: nil,
+        model2: { table: :model2_table }
+      }
+      expected_result = {
+        model1: described_class.new(name: :model1),
+        model2: described_class.new(name: :model2, table: 'model2_table')
+      }
+
+      expect(described_class.make_keyed_by(:name, input)).to eq expected_result
+    end
+
+    it 'accepts values of Dbee::Model instances' do
+      input = { model1: described_class.new(name: :model1) }
+      expected_result = { model1: described_class.new(name: :model1) }
+      expect(described_class.make_keyed_by(:name, input)).to eq expected_result
+    end
+
+    it 'accepts values of Dbee::Model instances when the key attribute is a string' do
+      input = { model1: described_class.new(name: 'model1') }
+      expected_result = { model1: described_class.new(name: 'model1') }
+      expect(described_class.make_keyed_by(:name, input)).to eq expected_result
+    end
+
+    it 'raises an error when the input hash key is not equal to the name of the model' do
+      input = { model1: described_class.new(name: :bogus) }
+      expect do
+        described_class.make_keyed_by(:name, input)
+      end.to raise_error ArgumentError, "expected a name of 'model1' but got 'bogus'"
+    end
+  end
+
   describe '#to_s' do
     it 'is represented by the model name' do
       expect(described_class.new(name: 'foo').to_s).to eq 'foo'

--- a/spec/dbee/model_spec.rb
+++ b/spec/dbee/model_spec.rb
@@ -62,8 +62,8 @@ describe Dbee::Model do
         model2: { table: :model2_table }
       }
       expected_result = {
-        model1: described_class.new(name: :model1),
-        model2: described_class.new(name: :model2, table: 'model2_table')
+        'model1' => described_class.new(name: 'model1'),
+        'model2' => described_class.new(name: 'model2', table: 'model2_table')
       }
 
       expect(described_class.make_keyed_by(:name, input)).to eq expected_result
@@ -71,13 +71,13 @@ describe Dbee::Model do
 
     it 'accepts values of Dbee::Model instances' do
       input = { model1: described_class.new(name: :model1) }
-      expected_result = { model1: described_class.new(name: :model1) }
+      expected_result = { 'model1' => described_class.new(name: :model1) }
       expect(described_class.make_keyed_by(:name, input)).to eq expected_result
     end
 
     it 'accepts values of Dbee::Model instances when the key attribute is a string' do
-      input = { model1: described_class.new(name: 'model1') }
-      expected_result = { model1: described_class.new(name: 'model1') }
+      input = { 'model1' => described_class.new(name: 'model1') }
+      expected_result = { 'model1' => described_class.new(name: 'model1') }
       expect(described_class.make_keyed_by(:name, input)).to eq expected_result
     end
 

--- a/spec/dbee/model_spec.rb
+++ b/spec/dbee/model_spec.rb
@@ -131,33 +131,40 @@ describe Dbee::Model do
     end
   end
 
-  describe 'equality' do
-    let(:config) { yaml_fixture('models.yaml')['Theaters, Members, and Movies Tree Based'] }
-    let(:model1) { described_class.make(config) }
-    let(:model2) { described_class.make(config) }
+  equality_cases = {
+    tree_based: yaml_fixture('models.yaml')['Theaters, Members, and Movies Tree Based'],
+    graph_based: yaml_fixture('models.yaml')['Theaters, Members, and Movies from DSL']['theater']
+  }
+  equality_cases[:graph_based].merge!(name: 'theaters')
 
-    subject { described_class.make(config) }
+  equality_cases.each do |test_case, config|
+    describe "equality for #{test_case}" do
+      let(:model1) { described_class.make(config) }
+      let(:model2) { described_class.make(config) }
 
-    specify 'equality compares attributes' do
-      expect(model1).to eq(model2)
-      expect(model1).to eql(model2)
-    end
+      subject { described_class.make(config) }
 
-    it 'returns false unless comparing same object types' do
-      expect(subject).not_to eq(config)
-      expect(subject).not_to eq(nil)
-    end
-
-    describe 'hash codes' do
-      specify 'are equal when objects are equal' do
+      specify 'equality compares attributes' do
         expect(model1).to eq(model2)
-        expect(model1.hash).to eq(model2.hash)
+        expect(model1).to eql(model2)
       end
 
-      specify 'are not equal when objects are not equal' do
-        different_model = described_class.new(name: :oddball)
-        expect(model1).not_to eq(different_model)
-        expect(model1.hash).not_to eq(different_model.hash)
+      it 'returns false unless comparing same object types' do
+        expect(subject).not_to eq(config)
+        expect(subject).not_to eq(nil)
+      end
+
+      describe 'hash codes' do
+        specify 'are equal when objects are equal' do
+          expect(model1).to eq(model2)
+          expect(model1.hash).to eq(model2.hash)
+        end
+
+        specify 'are not equal when objects are not equal' do
+          different_model = described_class.new(name: :oddball)
+          expect(model1).not_to eq(different_model)
+          expect(model1.hash).not_to eq(different_model.hash)
+        end
       end
     end
   end

--- a/spec/dbee/schema_creator_spec.rb
+++ b/spec/dbee/schema_creator_spec.rb
@@ -98,8 +98,8 @@ describe Dbee::SchemaCreator do
       end
 
       it 'creates a schema from a minimal hash model with no child models' do
-        minimal_tree_hash = { name: :practice }
-        minimal_schema =  Dbee::Schema.new(practice: nil)
+        minimal_tree_hash = { name: 'practice' }
+        minimal_schema =  Dbee::Schema.new('practice' => nil)
 
         expect(described_class.new(minimal_tree_hash, {}).schema).to eq minimal_schema
       end

--- a/spec/dbee/schema_creator_spec.rb
+++ b/spec/dbee/schema_creator_spec.rb
@@ -15,7 +15,7 @@ describe Dbee::SchemaCreator do
     {
       'model1' => {
         relationships: {
-          'model2' => {
+          model2: {
             constraints: [
               {
                 type: 'reference',
@@ -99,8 +99,8 @@ describe Dbee::SchemaCreator do
       end
 
       it 'creates a schema from a minimal hash model with no child models' do
-        minimal_tree_hash = { name: 'practice' }
-        minimal_schema =  Dbee::Schema.new('practice' => nil)
+        minimal_tree_hash = { name: :practice }
+        minimal_schema =  Dbee::Schema.new(practice: nil)
 
         expect(described_class.new(minimal_tree_hash, {}).schema).to eq minimal_schema
       end

--- a/spec/dbee/schema_creator_spec.rb
+++ b/spec/dbee/schema_creator_spec.rb
@@ -14,16 +14,17 @@ describe Dbee::SchemaCreator do
   let(:model_hash_graph) do
     {
       'model1' => {
-        relationships: [
-          name: 'model2',
-          constraints: [
-            {
-              type: 'reference',
-              parent: 'id',
-              name: 'model1_id'
-            }
-          ]
-        ]
+        relationships: {
+          'model2' => {
+            constraints: [
+              {
+                type: 'reference',
+                parent: 'id',
+                name: 'model1_id'
+              }
+            ]
+          }
+        }
       },
       'model2' => nil
     }

--- a/spec/fixtures/models.yaml
+++ b/spec/fixtures/models.yaml
@@ -126,7 +126,7 @@ Theaters, Members, and Movies from Tree:
   theater:
     table: theaters
     relationships:
-      - name: members
+      members:
         constraints:
           - type: reference
             parent: id
@@ -134,24 +134,24 @@ Theaters, Members, and Movies from Tree:
           - type: reference
             parent: partition
             name: partition
-      - name: parent_theater
+      parent_theater:
         constraints:
           - type: reference
             name: id
             parent: parent_theater_id
   members:
     relationships:
-      - name: demos
+      demos:
         constraints:
           - type: reference
             parent: id
             name: member_id
-      - name: movies
+      movies:
         constraints:
           - type: reference
             parent: id
             name: member_id
-      - name: favorite_comic_movies
+      favorite_comic_movies:
         constraints:
           - type: reference
             parent: id
@@ -159,7 +159,7 @@ Theaters, Members, and Movies from Tree:
           - type: static
             name: genre
             value: comic
-      - name: favorite_mystery_movies
+      favorite_mystery_movies:
         constraints:
           - type: reference
             parent: id
@@ -167,7 +167,7 @@ Theaters, Members, and Movies from Tree:
           - type: static
             name: genre
             value: mystery
-      - name: favorite_comedy_movies
+      favorite_comedy_movies:
         constraints:
           - type: reference
             parent: id
@@ -178,7 +178,7 @@ Theaters, Members, and Movies from Tree:
   demos:
     table: demographics
     relationships:
-      - name: phone_numbers
+      phone_numbers:
         constraints:
           - type: reference
             parent: id
@@ -194,7 +194,7 @@ Theaters, Members, and Movies from Tree:
   parent_theater:
     table: theaters
     relationships:
-      - name: members
+      members:
         constraints:
           - type: reference
             parent: id
@@ -207,7 +207,7 @@ Theaters, Members, and Movies from DSL:
   theater:
     table: theaters
     relationships:
-      - name: members
+      members:
         model: member
         constraints:
           - type: reference
@@ -216,7 +216,7 @@ Theaters, Members, and Movies from DSL:
           - type: reference
             parent: partition
             name: partition
-      - name: parent_theater
+      parent_theater:
         model: theater
         constraints:
           - type: reference
@@ -225,19 +225,19 @@ Theaters, Members, and Movies from DSL:
   member:
     table: members
     relationships:
-      - name: movies
+      movies:
         model: movie
         constraints:
           - type: reference
             parent: id
             name: member_id
-      - name: demos
+      demos:
         model: demographic
         constraints:
           - type: reference
             parent: id
             name: member_id
-      - name: favorite_comic_movies
+      favorite_comic_movies:
         model: movie
         constraints:
           - type: reference
@@ -246,7 +246,7 @@ Theaters, Members, and Movies from DSL:
           - type: static
             name: genre
             value: comic
-      - name: favorite_mystery_movies
+      favorite_mystery_movies:
         model: movie
         constraints:
           - type: reference
@@ -255,7 +255,7 @@ Theaters, Members, and Movies from DSL:
           - type: static
             name: genre
             value: mystery
-      - name: favorite_comedy_movies
+      favorite_comedy_movies:
         model: movie
         constraints:
           - type: reference
@@ -267,7 +267,7 @@ Theaters, Members, and Movies from DSL:
   demographic:
     table: demographics
     relationships:
-      - name: phone_numbers
+      phone_numbers:
         model: phone_number
         constraints:
           - type: reference
@@ -282,7 +282,7 @@ Readme:
   practice:
     table: practices
     relationships:
-      - name: patients
+      patients:
         model: patient
         constraints:
           - type: reference
@@ -291,13 +291,13 @@ Readme:
   patient:
     table: patients
     relationships:
-      - name: notes
+      notes:
         model: note
         constraints:
           - type: reference
             name: patient_id
             parent: id
-      - name: work_phone_number
+      work_phone_number:
         model: phone_number
         constraints:
           - type: reference
@@ -306,7 +306,7 @@ Readme:
           - type: static
             name: phone_number_type
             value: work
-      - name: cell_phone_number
+      cell_phone_number:
         model: phone_number
         constraints:
           - type: reference
@@ -315,7 +315,7 @@ Readme:
           - type: static
             name: phone_number_type
             value: cell
-      - name: fax_phone_number
+      fax_phone_number:
         model: phone_number
         constraints:
           - type: reference
@@ -376,23 +376,23 @@ Cycle Example:
   a:
     table: as
     relationships:
-      - name: b1
+      b1:
         model: b
-      - name: b2
+      b2:
         model: b
   b:
     table: bs
     relationships:
-      - name: c
-      - name: d
+      c:
+      d:
   c:
     table: cs
     relationships:
-      - name: a
+      a:
   d:
     table: ds
     relationships:
-      - name: a
+      a:
 
 Partitioner Example 1:
   dog:
@@ -407,7 +407,7 @@ Partitioner Example 2:
   owner:
     table: owners
     relationships:
-      - name: dogs
+      dogs:
         model: dog
         constraints:
           - name: owner_id


### PR DESCRIPTION
This addresses an issue in #33 where there was in inconsistency between the specification format for models and relationships. With this change, both models and relationships are hash based instead of models being keyed by name and relationships being a list. This change also brings the line test coverage back up to 100% as it is on master.